### PR TITLE
Fix LaTeX ISO rice compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL ?= /bin/bash
 METANORMA_PREFIX ?= docker run -v $(shell pwd):/metanorma metanorma/metanorma
 
-TEX  := $(wildcard sections-en/*.tex)
+TEX  := $(wildcard *.tex)
 LXML := $(patsubst %.tex,%.lxml,$(TEX))
 ADOC := $(patsubst %.tex,%.adoc,$(TEX))
 HTML := $(patsubst %.tex,%.html,$(TEX))
@@ -10,15 +10,15 @@ PDF  := $(patsubst %.tex,%.pdf,$(TEX))
 
 MNXSL := tex2mn/Metanorma.xsl
 
-all: $(HTML)
+all: $(ADOC) $(HTML)
 
 clear:
-	rm -f $(LSXML) $(ADOC)
+	rm -f $(LXML) $(ADOC) *.err *.presentation.xml
 	latexmk -c $(TEX)
 
 clobber: clear
 	rm -f $(HTML)
-	latexmk -C iso-rice-en.tex
+	latexmk -C $(TEX)
 
 %.lxml: %.tex
 	latexml \

--- a/Metanorma.cls
+++ b/Metanorma.cls
@@ -1,0 +1,1 @@
+tex2mn/Metanorma.cls

--- a/Metanorma.cls.ltxml
+++ b/Metanorma.cls.ltxml
@@ -1,0 +1,1 @@
+tex2mn/Metanorma.cls.ltxml

--- a/iso-rice-en.tex
+++ b/iso-rice-en.tex
@@ -1,0 +1,50 @@
+\documentclass{Metanorma}
+
+\title{Rice model}
+\set{docnumber}{17301}
+\set{tc-docnumber}{17301}
+\set{partnumber}{1}
+\set{edition}{2}
+\set{revdate}{2016-05-01}
+\set{copyright-year}{2016}
+\set{language}{en}
+\set{title-intro-en}{Cereals and pulses}
+\set{title-main-en}{Specifications and test methods}
+\set{title-part-en}{Rice (Final)}
+\set{title-intro-fr}{Céréales et légumineuses}
+\set{title-main-fr}{Spécification et méthodes d'essai}
+\set{title-part-fr}{Riz (Final)}
+\set{doctype}{international-standard}
+\set{docstage}{60}
+\set{docsubstage}{60}
+\set{technical-committee-number}{34}
+\set{secretariat}{SAC}
+\set{technical-committee}{Food products}
+\set{subcommittee-number}{4}
+\set{subcommittee}{Cereals and pulses}
+\set{workgroup-type}{WG}
+\set{workgroup-number}{4}
+\set{workgroup}{Amylose in rice}
+\set{docfile}{iso-rice-en.adoc}
+\set{library-ics}{67.060}
+\set{mn-document-class}{iso}
+\set{mn-output-extensions}{xml,html,doc,html_alt,pdf,rxl}
+\set{local-cache-only}{}
+\set{data-uri-image}{}
+
+\begin{document}
+
+\maketitle
+\tableofcontents
+\bigskip
+
+\include{sections-en/00-foreword}
+\include{sections-en/00-introduction}
+\include{sections-en/02-normref}
+\include{sections-en/03-termdef}
+\include{sections-en/07-testreport}
+\include{sections-en/08-packaging}
+\include{sections-en/aa-annex-a}
+\include{sections-en/b0-bibliography}
+
+\end{document}

--- a/sections-en/00-foreword.tex
+++ b/sections-en/00-foreword.tex
@@ -1,4 +1,5 @@
 \section{foreword}
+\mn{.foreword}
 
 ISO (the International Organization for Standardization)
 is a worldwide federation of national standards bodies (ISO member bodies). The work of preparing International Standards is normally carried out through ISO technical committees. Each member body interested in a subject for which a technical committee has been established has the right to be represented on that committee. International organizations, governmental and non-governmental, in liaison with ISO, also take part in the work. ISO collaborates closely with the International Electrotechnical Commission (IEC) on all matters of electrotechnical standardization.

--- a/sections-en/aa-annex-a.tex
+++ b/sections-en/aa-annex-a.tex
@@ -1,5 +1,5 @@
-% [appendix,obligation=normative]
 \section{Determination of defects}
+\mn{appendix,obligation=normative}
 \label{AnnexA}
 
 \subsection{Principle}


### PR DESCRIPTION
*As requested in https://github.com/metanorma/mn-samples-tex-iso/issues/3*

Comments:
- TeX preamble was added. (`iso-rice-en.tex`.)
- `Makefile` was updated
- I struggled to bind the `Metanorma.cls` and `Metanorma.cls.ltxml` files (located in `tex2mn` sub-folder) from the root folder. So I used soft links for that purpose.
- I couldn't find a way to set a section attribute (like `[.preface]`) in LaTeX markup. I have opened a question ticket in https://github.com/metanorma/tex2mn/issues/98

Thanks!